### PR TITLE
#45 이메일 기반 유저 조회 API 수정

### DIFF
--- a/src/apis/users/interfaces/user.interface.ts
+++ b/src/apis/users/interfaces/user.interface.ts
@@ -1,3 +1,7 @@
+export interface IUsersServiceFindOneUser {
+    email: string
+}
+
 export interface IUsersServiceFindOneByEmail {
     email: string
 }

--- a/src/apis/users/users.controller.ts
+++ b/src/apis/users/users.controller.ts
@@ -62,6 +62,6 @@ export class UsersController {
         type: Error,
     })
     async fetchUser(@Param('email') email: string): Promise<User> {
-        return await this.usersService.findOneByEmail({ email })
+        return await this.usersService.findOneUser({ email })
     }
 }

--- a/src/apis/users/users.service.ts
+++ b/src/apis/users/users.service.ts
@@ -26,6 +26,16 @@ export class UsersService {
         private reviewService: ReviewsService
     ) {}
 
+    async findOneUser({ email }: IUsersServiceFindOneByEmail): Promise<User> {
+        const user = await this.findOneByEmail({ email })
+
+        if (!user) {
+            throw new UnprocessableEntityException('유저가 존재하지 않습니다')
+        }
+
+        return user
+    }
+
     async findOneById({ userId }: IUsersServiceFindOneById): Promise<User> {
         const user = await this.usersRepository.findOne({
             where: { id: userId },
@@ -44,9 +54,6 @@ export class UsersService {
         const user = await this.usersRepository.findOne({
             where: { email },
         })
-
-        if (!user)
-            throw new UnprocessableEntityException('유저가 존재하지 않습니다')
 
         return user
     }

--- a/src/apis/users/users.service.ts
+++ b/src/apis/users/users.service.ts
@@ -12,6 +12,7 @@ import {
     IUsersServiceDelete,
     IUsersServiceFindOneByEmail,
     IUsersServiceFindOneById,
+    IUsersServiceFindOneUser,
 } from './interfaces/user.interface'
 import { CreateUserDto } from './dto/createUser.dto'
 import { ReviewsService } from '../reviews/reviews.service'
@@ -26,7 +27,7 @@ export class UsersService {
         private reviewService: ReviewsService
     ) {}
 
-    async findOneUser({ email }: IUsersServiceFindOneByEmail): Promise<User> {
+    async findOneUser({ email }: IUsersServiceFindOneUser): Promise<User> {
         const user = await this.findOneByEmail({ email })
 
         if (!user) {


### PR DESCRIPTION
- findOneUser 로직 추가
  : findOneByEmail 로직은 소셜로그인 시 사용되어서 유저가 존재하지 않을때에 대한 예외처리를 하지 못함.